### PR TITLE
Fixed findAll result

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,9 +73,7 @@ Cacher.prototype.fetchFromDatabase = function fetchFromDatabase(key) {
         if (!results) {
           res = results;
         } else if (Array.isArray(results)) {
-          res = results.map(function map(result) {
-            return result.get({ plain: true });
-          });
+          res = results;
         } else if (results.toString() === '[object SequelizeInstance]') {
           res = results.get({ plain: true });
         } else {


### PR DESCRIPTION
``` results.get({ plain: true }) ``` should be called for only ``` [object SequelizeInstance] ```.
Data  was changed to undefined in findAll case.