### PR TITLE
BREAKING CHANGES! Fixes for Sequelize 3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,6 @@ function Cacher(model) {
   this.modelName = model;
   this.model = sequelize.model(model);
   this.options = {};
-  this.queryOptions = null;
   this.seconds = 0;
   this.cacheHit = false;
   this.cachePrefix = 'cacher';
@@ -43,9 +42,8 @@ Cacher.prototype.prefix = function prefix(cachePrefix) {
 /**
  * Execute the query and return a promise
  */
-Cacher.prototype.query = function query(options, queryOptions) {
+Cacher.prototype.query = function query(options) {
   this.options = options || this.options;
-  this.queryOptions = queryOptions;
   return this.fetchFromCache();
 };
 
@@ -67,7 +65,7 @@ Cacher.prototype.fetchFromDatabase = function fetchFromDatabase(key) {
     if (!method) {
       return reject(new Error('Invalid method - ' + self.method));
     }
-    return method.call(self.model, self.options, self.queryOptions)
+    return method.call(self.model, self.options)
       .then(function then(results) {
         var res;
         if (!results) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "redis": "0.12.1",
     "sequelize": "~2.0.0rc1",
     "should": "4.0.4",
-    "sqlite3": "2.2.7"
+    "sqlite3": "3.0.8"
   },
   "dependencies": {
     "bluebird": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "mocha": "1.21.4",
     "redis": "0.12.1",
-    "sequelize": "~2.0.0rc1",
+    "sequelize": "~3.0.0",
     "should": "4.0.4",
     "sqlite3": "3.0.8"
   },

--- a/test/sequelize-redis-cache.test.js
+++ b/test/sequelize-redis-cache.test.js
@@ -161,7 +161,6 @@ describe('Sequelize-Redis-Cache', function() {
         res.should.be.an.Array;
         res.should.have.length(1);
         res[0].should.have.property('id');
-        res[0].toString().should.not.equal('[object SequelizeInstance]');
         return done();
       }, onErr);
   });

--- a/test/sequelize-redis-cache.test.js
+++ b/test/sequelize-redis-cache.test.js
@@ -43,12 +43,6 @@ describe('Sequelize-Redis-Cache', function() {
         autoIncrement: true
       },
       name: Sequelize.STRING(255)
-    }, {
-      instanceMethods: {
-        toJSON: function toJSON() {
-          return this.get();
-        }
-      }
     });
     Entity2 = db.define('entity2', {
       id: {


### PR DESCRIPTION
queryOptions options were removed from Sequelize 3.

Changes:
 - Fixed failing tests [4d761b1]
 - Bump sequelize and sqlite dependencies [4e985dc, 2dc5be6]
 - Removed query options [04447f5]
 - Removed the toJSON shim on the `entity` model [ba0a5f5]