### PR TITLE
Added redis readycheck, fallback to db query if unavailable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,10 @@ Cacher.prototype.prefix = function prefix(cachePrefix) {
  */
 Cacher.prototype.query = function query(options) {
   this.options = options || this.options;
-  return this.fetchFromCache();
+
+  return redis.ready 
+    ? this.fetchFromCache() 
+    : this.fetchFromDatabase(this.options.key, true);
 };
 
 /**
@@ -58,7 +61,7 @@ Cacher.prototype.ttl = function ttl(seconds) {
 /**
  * Fetch from the database
  */
-Cacher.prototype.fetchFromDatabase = function fetchFromDatabase(key) {
+Cacher.prototype.fetchFromDatabase = function fetchFromDatabase(key, nocache) {
   var method = this.model[this.method];
   var self = this;
   this.cacheHit = false;
@@ -78,6 +81,10 @@ Cacher.prototype.fetchFromDatabase = function fetchFromDatabase(key) {
         } else {
           res = results;
         }
+
+        if (nocache)
+          return resolve(res);
+
         return self.setCache(key, res, self.seconds)
           .then(
             function good() {


### PR DESCRIPTION
Added a Redis client ready check to ensure that the client is available when cache object requested. If unavailable, will hit the database and run query as normal. Resolves promise with db object prior to setting cache if 'nocache' argument passed to fetchFromDatabase method.