### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var Sequelize = require('sequelize');
 
 var rc = redis.createClient(6379, 'localhost');
 var db = new Sequelize('cache_tester', 'root', 'root', { dialect: 'mysql' });
-var cacher = initCache(db, rc);
+var cacher = initCacher(db, rc);
 
 var cacheObj = cacher('sequelize-model-name')
   .ttl(5);


### PR DESCRIPTION
I ran the example but realized that there was a typo in the README.md.

```
var initCacher = require('sequelize-redis-cache');
var cacher = initCache(db, rc);
```

should be:


```
var initCacher = require('sequelize-redis-cache');
var cacher = initCacher(db, rc);
```