### PR TITLE
Support for .scope() from sequelize

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 var Promise = require('bluebird');
 var CircularJSON = require('circular-json');
 var crypto = require('crypto');
-var _ = require('lodash');
 
 module.exports = Cacher;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var Promise = require('bluebird');
 var CircularJSON = require('circular-json');
 var crypto = require('crypto');
+var _ = require('lodash');
 
 module.exports = Cacher;
 
@@ -17,6 +18,8 @@ function Cacher(seq, red) {
   this.options = {};
   this.seconds = 0;
   this.cacheHit = false;
+  this.scoped = false;
+  this.scopes = {};
   this.cachePrefix = 'cacher';
   this.sequelize = seq;
   this.redis = red;
@@ -28,6 +31,17 @@ function Cacher(seq, red) {
 Cacher.prototype.model = function model(md) {
   this.md = this.sequelize.model(md);
   this.modelName = md;
+  return this;
+};
+
+/**
+ * Set scope
+ */
+Cacher.prototype.scope = function scope() {
+  this.scoped = true;
+  this.scopes = arguments;
+
+  this.md = this.md.scope.apply(this.md, arguments);
   return this;
 };
 
@@ -240,9 +254,20 @@ Cacher.prototype.key = function key() {
       .digest('hex');
     return [this.cachePrefix, '__raw__', 'query', hash].join(':');
   }
+
   hash = crypto.createHash('sha1')
     .update(CircularJSON.stringify(this.options, jsonReplacer))
     .digest('hex');
+
+
+  if (this.scoped) {
+    const scopedHash = crypto.createHash('sha1')
+      .update(CircularJSON.stringify(this.scopes, jsonReplacer))
+      .digest('hex');
+
+    return [this.cachePrefix, this.modelName, this.method, hash, scopedHash].join(':');
+  }
+
   return [this.cachePrefix, this.modelName, this.method, hash].join(':');
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -260,7 +260,7 @@ Cacher.prototype.key = function key() {
 
 
   if (this.scoped) {
-    const scopedHash = crypto.createHash('sha1')
+    var scopedHash = crypto.createHash('sha1')
       .update(CircularJSON.stringify(this.scopes, jsonReplacer))
       .digest('hex');
 


### PR DESCRIPTION
This passes the arguments through to the model in order to perform the proper SQL generation. The scopes are saved in order to add an additional key path to the redis key for retrieving the stored, scoped, request. 